### PR TITLE
✨ feat: 설문조사에 들어가는 플레이타임을 장고 어드민으로 관리할 수 있게 기능 구현

### DIFF
--- a/apps/games/admin.py
+++ b/apps/games/admin.py
@@ -4,7 +4,7 @@ from apps.games.models import PlaytimeCategory
 
 
 @admin.register(PlaytimeCategory)
-class PlaytimeCategoryAdmin(admin.ModelAdmin): # type: ignore[type-arg]
+class PlaytimeCategoryAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = ("playtime_id", "name", "min_minutes", "max_minutes")
     search_fields = ("name",)
     ordering = ("min_minutes",)

--- a/apps/games/admin.py
+++ b/apps/games/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
 
-# Register your models here.
+from apps.games.models import PlaytimeCategory
+
+
+@admin.register(PlaytimeCategory)
+class PlaytimeCategoryAdmin(admin.ModelAdmin): # type: ignore[type-arg]
+    list_display = ("playtime_id", "name", "min_minutes", "max_minutes")
+    search_fields = ("name",)
+    ordering = ("min_minutes",)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -19,6 +19,7 @@ ALLOWED_HOSTS: list[str | None] = []
 
 # Application definition
 DJANGO_APPS = [
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib import admin
 from django.urls import URLPattern, URLResolver, include, path
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -7,6 +8,7 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
+    path("admin/", admin.site.urls),
     path("api/v1/", include("apps.games.urls"), name="games"),
     path("api/v1/", include("apps.users.urls"), name="users"),
 ]


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 설문조사에 들어가는 플레이타임을 장고 어드민으로 관리할 수 있게 기능 구현
- 
## 📄 상세 내용
- [ ] games/admin.py - 플레이타임 카테고리 작성
- [ ] config/settings/base.py - 장고 앱에 django.contrib.admin 추가
- [ ] 장고 어드민 url 추가
- [ ] 
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
플레이타임 카테고리는 장고 어드민으로 관리하기로 협의해서 api는 작성하지 않았습니다.

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
